### PR TITLE
Bump kernel to 3.16.0

### DIFF
--- a/scripts/create-akanda-raw-image.sh
+++ b/scripts/create-akanda-raw-image.sh
@@ -63,8 +63,8 @@ EOF
 echo "[*] APT Update"
 apt-get update || exit 1
 
-echo "[*] Upgrade to the 3.14 backport kernel and update bash to fix CVE-2014-6271"
-apt-get -y install linux-image-3.14-0.bpo.2-amd64 bash
+echo "[*] Upgrade to the 3.14 (or greater) backport kernel and update bash to fix CVE-2014-6271"
+apt-get -y install linux-image-3.16.0-0.bpo.4-amd64 bash
 
 echo "[*] Creating motd file..."
 cat >/etc/motd <<EOF


### PR DESCRIPTION
In order to address CVE-2014-6271, the 3.14 kernel is needed.  However,
this kernel is no longer available in the repos (3.16.0 is now
available).  As such, this patch bumps the kernel to > 3.14.
