### PR TITLE
Raise ipv4 and ipv6 neighbor thresholds

### DIFF
--- a/scripts/create-akanda-raw-image.sh
+++ b/scripts/create-akanda-raw-image.sh
@@ -146,6 +146,12 @@ net.ipv6.conf.eth2.accept_dad=0
 net.ipv4.conf.all.arp_announce=2
 net.ipv4.conf.default.arp_notify=1
 net.ipv4.conf.all.arp_notify=1
+net.ipv4.neigh.default.gc_thresh1=4096
+net.ipv4.neigh.default.gc_thresh2=8192
+net.ipv4.neigh.default.gc_thresh3=8192
+net.ipv6.neigh.default.gc_thresh1=4096
+net.ipv6.neigh.default.gc_thresh2=8192
+net.ipv6.neigh.default.gc_thresh3=8192
 EOF
 
 echo "[*] Disable fsck on boot"


### PR DESCRIPTION
Defaults for these start at 128 which is much too low for a cluster
the size of masseffect. Raising these should result in less neighbor
discovery traffic which can beat up OVS.
