### PR TITLE
Use SNAT (instead of masquerade) for fixed-to-floating traffic.

### DIFF
--- a/test/unit/drivers/test_iptables.py
+++ b/test/unit/drivers/test_iptables.py
@@ -77,7 +77,7 @@ V4_OUTPUT = [
     ':PUBLIC_SNAT - [0:0]',
     '-A PUBLIC_SNAT -m mark --mark 0xACDA -j RETURN',
     '-A PUBLIC_SNAT -s 192.168.0.2 -j SNAT --to 172.16.77.50',
-    '-A PUBLIC_SNAT ! -o eth0 -j MASQUERADE',
+    '-A PUBLIC_SNAT ! -o eth0 -j SNAT --to 172.16.77.2',
     ':PREROUTING ACCEPT [0:0]',
     ':INPUT ACCEPT [0:0]',
     ':OUTPUT ACCEPT [0:0]',


### PR DESCRIPTION
This fixes a bug whereby traffic from fixed IPs to floating IPs was using the
router as the source address.
