### PR TITLE
Don't truncate interface parsing past the ninth interface.

### DIFF
--- a/akanda/router/drivers/ip.py
+++ b/akanda/router/drivers/ip.py
@@ -499,7 +499,7 @@ def _parse_interfaces(data, filters=None):
     :rtype: list of akanda.router.models.Interface
     """
     retval = []
-    for iface_data in re.split('(^|\n)(?=[0-9]: \w+\d{0,3}:)', data, re.M):
+    for iface_data in re.split('(^|\n)(?=[0-9]: \w+\d{0,3}:)', data):
         if not iface_data.strip():
             continue
         number, interface = iface_data.split(': ', 1)


### PR DESCRIPTION
The third argument to re.split is the _maxlength_, not flags.  This causes an
odd bug whereby every interface _past_ number eight isn't properly parsed.
